### PR TITLE
Fixed card page

### DIFF
--- a/src/app/card/card.page.html
+++ b/src/app/card/card.page.html
@@ -48,9 +48,9 @@
                       <app-card-text [text]="cardData.text"></app-card-text>
                     </div>
 
-                    @if(template) {
+                    @if(template()) {
                     <br>
-                    <div [innerHTML]="template"></div>
+                    <div [innerHTML]="template()"></div>
                     }
                   </ion-label>
                 </ion-item>

--- a/src/app/card/card.page.html
+++ b/src/app/card/card.page.html
@@ -17,7 +17,7 @@
           @if(cardData.flipSide) {
           <ion-row>
             <ion-col class="flip-col">
-              <ion-button color="secondary" (click)="loadCardData(cardData.flipSide)">Flip Card</ion-button>
+              <ion-button color="secondary" [routerLink]="['/card', cardData.flipSide]">Flip Card</ion-button>
             </ion-col>
           </ion-row>
           }

--- a/src/app/card/card.page.ts
+++ b/src/app/card/card.page.ts
@@ -3,20 +3,17 @@ import {
   computed,
   effect,
   inject,
-  signal,
-  untracked,
   viewChild,
   type ElementRef,
   type OnDestroy,
   type OnInit,
   type Signal,
-  type WritableSignal,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import {
-  type ICard,
-  type ICardErrataEntry,
-  type ICardFAQEntry,
+import type {
+  ICard,
+  ICardErrataEntry,
+  ICardFAQEntry,
 } from '../../../interfaces';
 import { CardsService } from '../cards.service';
 import { MetaService } from '../meta.service';
@@ -29,9 +26,9 @@ import { environment } from '../../environments/environment';
 import { WINDOW } from '../_shared/helpers';
 import { ErrataService } from '../errata.service';
 import { FAQService } from '../faq.service';
-import { LocaleService } from '../locale.service';
 import { NotifyService } from '../notify.service';
 import { SEOService } from '../seo.service';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-card',
@@ -49,15 +46,26 @@ export class CardPage implements OnInit, OnDestroy {
   private seo = inject(SEOService);
 
   private translateService = inject(TranslateService);
-  private localeService = inject(LocaleService);
   private cardsService = inject(CardsService);
   private faqService = inject(FAQService);
   private errataService = inject(ErrataService);
   public metaService = inject(MetaService);
   public notify = inject(NotifyService);
 
-  public cardData: WritableSignal<ICard | undefined> = signal(undefined);
-  public template = '';
+  private routeParamMap = toSignal(this.route.paramMap, { initialValue: this.route.snapshot.paramMap });
+  public cardData = computed(() => {
+    const id = this.routeParamMap().get('id');
+    return id ? this.cardsService.getCardById(id) : undefined
+  });
+
+  public template = computed(() => {
+    const cardData = this.cardData();
+    if (!cardData) return "";
+
+    const template = this.metaService.getTemplateByProductId(cardData.game);
+    const compiled = Handlebars.compile(template);
+    return compiled(cardData)
+  });
 
   public get copyText(): string {
     const location = this.window.location;
@@ -90,20 +98,22 @@ export class CardPage implements OnInit, OnDestroy {
 
   constructor() {
     effect(() => {
-      if (!this.cardData) return;
+      const data = this.cardData();
+      if (data) this.updateMeta(data);
+    })
 
-      this.localeService.currentLocale();
-
-      untracked(() => {
-        this.loadCardData(this.route.snapshot.paramMap.get('id') ?? '');
-      });
-    });
+    // Redirect to the home page if this card doesn't exist, but take care
+    // to only do it after the fetch of card data is complete
+    effect(() => {
+      if (this.cardsService.loaded) {
+        if (!this.cardData()) {
+          this.router.navigate(['/']);
+        }
+      }
+    })
   }
 
   ngOnInit() {
-    const cardId = this.route.snapshot.paramMap.get('id');
-    this.loadCardData(cardId ?? '');
-
     this.clickListener = this.cardPage()?.nativeElement.addEventListener(
       'click',
       (evt: Event) => {
@@ -144,38 +154,6 @@ export class CardPage implements OnInit, OnDestroy {
     }
 
     this.document.querySelector('#card-metadata')?.remove();
-  }
-
-  loadCardData(id: string) {
-    const cardData = this.cardsService.getCardById(id);
-
-    if (!cardData) {
-      this.router.navigate(['/']);
-      return;
-    }
-
-    const template = this.metaService.getTemplateByProductId(cardData.game);
-    const compiledTemplate = Handlebars.compile(template ?? '');
-    this.template = compiledTemplate(cardData);
-
-    this.cardData.set(cardData);
-
-    this.updateMeta(cardData);
-
-    /*
-    I might like to do something like one of these, but I want to replace the url without doing a nav.
-    But, they don't currently work right. Either it does a navigation event (latter), or it won't load you load into the page directly (former).
-
-    this.location.replaceState(
-      `/card/${id}`,
-      `q=${this.route.snapshot.queryParamMap.get('q') ?? ''}`
-    );
-
-    this.router.navigate(['/card', id], {
-      queryParams: { q: this.route.snapshot.queryParamMap.get('q') ?? '' },
-      replaceUrl: true,
-    });
-    */
   }
 
   search(query: string) {

--- a/src/app/cards.service.ts
+++ b/src/app/cards.service.ts
@@ -1,11 +1,11 @@
-import { inject, Injectable } from '@angular/core';
+import { computed, inject, Injectable, signal, type Signal, type WritableSignal } from '@angular/core';
 
 import { decompress } from 'compress-json';
 import { sortBy } from 'lodash';
 
 import { HttpClient } from '@angular/common/http';
 import { of } from 'rxjs';
-import { type ICard, type IProductFilter } from '../../interfaces';
+import type { ICard, IProductFilter } from '../../interfaces';
 import { numericalOperator } from '../../search/operators/_helpers';
 import { parseQuery, type ParserOperator } from '../../search/search';
 import { environment } from '../environments/environment';
@@ -18,9 +18,13 @@ import { MetaService } from './meta.service';
   providedIn: 'root',
 })
 export class CardsService {
-  private cards: ICard[] = [];
-  private cardsByName: Record<string, ICard> = {};
-  private cardsById: Record<string, ICard> = {};
+  private cards: WritableSignal<ICard[] | null> = signal(null);
+  private cardsByName: Signal<Record<string, ICard>> = computed(
+    () => Object.fromEntries((this.allCards).map(card => [card.name, card]))
+  );
+  private cardsById: Signal<Record<string, ICard>> = computed(
+    () => Object.fromEntries((this.allCards).map(card => [card.id, card]))
+  );
 
   private http = inject(HttpClient);
   private localeService = inject(LocaleService);
@@ -29,14 +33,19 @@ export class CardsService {
   private errataService = inject(ErrataService);
 
   public get allCards(): ICard[] {
-    return this.cards;
+    return this.cards() ?? [];
+  }
+
+  // Returns true if the service has finished the initial fetch of card data.
+  public get loaded(): boolean {
+    return this.cards() !== null
   }
 
   public init() {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const finishLoad = (realData: any) => {
       const allCards = decompress(realData);
-      this.setCards(allCards);
+      this.cards.set(allCards)
     };
 
     if (environment.overrideData.cardsMin) {
@@ -53,28 +62,18 @@ export class CardsService {
     return obs;
   }
 
-  private setCards(cards: ICard[]) {
-    this.cards = cards;
-
-    this.cards.forEach((card) => {
-      this.cardsByName[card.name] = card;
-      this.cardsById[card.id] = card;
-    });
-  }
 
   // card utilities
-  private reformatCardsWithErrataAndFAQ(): ICard[] {
-    return this.cards.map((card) => ({
-      ...card,
-      faq: this.faqService.getCardFAQ(card.game, card).length ?? 0,
-      errata:
-        this.errataService.getCardErrata(card.game, card.name).length ?? 0,
-    }));
-  }
+  private reformatCardsWithErrataAndFAQ: Signal<ICard[]> = computed(() => this.allCards.map(card => ({
+    ...card,
+    faq: this.faqService.getCardFAQ(card.game, card).length ?? 0,
+    errata:
+      this.errataService.getCardErrata(card.game, card.name).length ?? 0,
+  })))
 
   public getCardByIdOrName(codeOrName: string): ICard | undefined {
     return (
-      this.cardsById[codeOrName] ?? this.cardsByName[codeOrName] ?? undefined
+      this.cardsById()[codeOrName] ?? this.cardsByName()[codeOrName] ?? undefined
     );
   }
 
@@ -105,7 +104,7 @@ export class CardsService {
   }
 
   public getCardById(id: string): ICard | undefined {
-    return this.cards.find(
+    return this.allCards.find(
       (c) =>
         c.id.toLowerCase() === id.toLowerCase() &&
         c.locale === this.localeService.currentLocale()
@@ -114,7 +113,7 @@ export class CardsService {
 
   public getAllUniqueAttributes(attribute: keyof ICard): string[] {
     return sortBy(
-      Array.from(new Set(this.cards.map((c) => c[attribute]).flat())),
+      Array.from(new Set(this.allCards.map((c) => c[attribute]).flat())),
       (x) => x?.toString().toLowerCase()
     ) as string[];
   }


### PR DESCRIPTION
# Description

This PR fixes the way that the Card page and Cards service load card data, making more use of computed signals instead of manual state sync to make this data available. The overall effect is to fix the bug where the app often navigates away from `/card/CARD-ID` to `/` the first time you load it, especially in mobile browsers.

Reattempt of #156 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works
